### PR TITLE
Include DeploymentTags property to desired state

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/Microsoft/vsts-agent-cookbook' if respond_to?(:source_url)
 issues_url       'https://github.com/Microsoft/vsts-agent-cookbook/issues' if respond_to?(:issues_url)
 chef_version     '>= 12.4' if respond_to?(:chef_version)
-version          '3.0.1'
+version          '3.1.0'
 
 %w(ubuntu debian redhat centos mac_os_x windows).each do |operating_system|
   supports operating_system

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -30,7 +30,7 @@ property :vsts_token, String, sensitive: true, desired_state: false
 # Deployment Groups
 property :deploymentGroup, [TrueClass, FalseClass], default: false
 property :deploymentGroupName, String
-property :deploymentGroupTags, String, desired_state: false
+property :deploymentGroupTags, String
 property :projectName, String
 property :collectionName, String, default: 'DefaultCollection'
 
@@ -49,6 +49,7 @@ load_current_value do
   work_folder state['work_folder']
   deploymentGroup state['deploymentGroup']
   deploymentGroupName state['deploymentGroupName']
+  deploymentGroupTags state['deploymentGroupTags']
   projectName state['projectName']
   collectionName state['collectionName']
 
@@ -174,6 +175,7 @@ action :install do
                                             work_folder: new_resource.work_folder,
                                             deploymentGroup: new_resource.deploymentGroup,
                                             deploymentGroupName: new_resource.deploymentGroupName,
+                                            deploymentGroupTags: new_resource.deploymentGroupTags,
                                             projectName: new_resource.projectName,
                                             collectionName: new_resource.collectionName)
         Chef::Log.info "'#{new_resource.agent_name}' agent was installed"


### PR DESCRIPTION
Hello,

This change proposes that **vsts_agent** resource must be converged on changing **DeploymentTags**.

In our case we are using **DeploymentTags** to specify application types, which are installed on a target machine. So, we can orchestrate deployments easily. 
There can be multiple application types on the same machines and applications can be added/removed, especially in Dev/QA environments. 

Thanks!