### PR TITLE
Add support for forward proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following platforms are tested and supported:
 - Debian 8 x64 (Jessie)
 - Debian 9 x64 (Stretch)
 - Ubuntu 16.04 (Xenial Xerus)
+- Ubuntu 18.04 (Bionic)
 - Ubuntu 17.10 (Artful Aardvark)
 - CentOS 7
 - Windows 10
@@ -67,6 +68,8 @@ This resource installs and configures the vsts build and release agent
 - `vsts_username`: A user to connect to VSTS. Used with Negotiate and ALT auth
 - `vsts_password`: A user to connect to VSTS. Used with Negotiate and ALT auth
 - `work_folder`: Set different workspace location. Default is "install_dir/\_work"
+- `proxy_url`: Set the forward proxy (example value: `http://192.168.1.1:8080`)
+- `proxy_sslcacert`: Set the root certificate which is used for communicating through the forward proxy (example value: `/usr/local/share/ca-certificates/Internal-CA.crt`)
 
 #### Examples
 Install, configure, restart and remove a build agent.

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -19,6 +19,10 @@ property :version, String, desired_state: false
 property :path, String, desired_state: false
 property :env, Hash, default: {}, desired_state: false
 
+# Proxy
+property :proxy_url, String
+property :proxy_sslcacert, String
+
 # VSTS Access
 property :vsts_url, String, regex: %r{^https?://.*$}
 property :vsts_pool, String
@@ -52,6 +56,8 @@ load_current_value do
   deploymentGroupTags state['deploymentGroupTags']
   projectName state['projectName']
   collectionName state['collectionName']
+  proxy_url state['proxy_url']
+  proxy_sslcacert state['proxy_sslcacert']
 
   runasservice service_exist?(install_dir)
 end
@@ -133,6 +139,14 @@ action :install do
       end
     end
 
+    if new_resource.proxy_url
+      args[:proxyurl] = new_resource.proxy_url
+    end
+
+    if new_resource.proxy_sslcacert
+      args[:sslcacert] = new_resource.proxy_sslcacert
+    end
+
     set_auth(args, new_resource)
 
     execute "Configuring agent '#{new_resource.agent_name}'" do
@@ -177,7 +191,9 @@ action :install do
                                             deploymentGroupName: new_resource.deploymentGroupName,
                                             deploymentGroupTags: new_resource.deploymentGroupTags,
                                             projectName: new_resource.projectName,
-                                            collectionName: new_resource.collectionName)
+                                            collectionName: new_resource.collectionName,
+                                            proxy_url: new_resource.proxy_url,
+                                            proxy_sslcacert: new_resource.proxy_sslcacert)
         Chef::Log.info "'#{new_resource.agent_name}' agent was installed"
       end
       action :run

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -139,13 +139,8 @@ action :install do
       end
     end
 
-    if new_resource.proxy_url
-      args[:proxyurl] = new_resource.proxy_url
-    end
-
-    if new_resource.proxy_sslcacert
-      args[:sslcacert] = new_resource.proxy_sslcacert
-    end
+    args[:proxyurl] = new_resource.proxy_url || nil
+    args[:sslcacert] = new_resource.proxy_sslcacert || nil
 
     set_auth(args, new_resource)
 


### PR DESCRIPTION
## Changes

- Added support for forward proxies

## How to test

```rb
vsts_agent "Test_Agent" do
    install_dir "/home/test/agent"
    work_folder "/home/test/temp"
    user "test"
    group "test"
    path '/usr/local/bin:/usr/bin:/bin:/opt/bin'
    vsts_url "https://dev.azure.com/...."
    vsts_pool "Test_Pool"
    vsts_token "XXXXXXXXXXXXXXXXX"
    proxy_url "http://192.168.1.1:8080"
    proxy_sslcacert "/usr/local/share/ca-certificates/Internal-CA.crt"
    action :install
end
```

The settings should be set in the config files located in the agents installation directory.