### PR TITLE
Remove windows dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,5 @@ version          '3.2.0'
   supports operating_system
 end
 
-depends 'windows'
 depends 'ark'
 depends 'seven_zip', '>= 2.0.0'


### PR DESCRIPTION
No idea why the windows cookbook is still a dependency. Most of the windows cookbook resources were merged into the Chef Client as far back as Chef 14 (Released April 2018).